### PR TITLE
Fix compilation error on Linux

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -110,7 +110,7 @@ recipe.objcopy.hex.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf
 recipe.objcopy.zip.pattern="{tools.nrfutil.cmd}" dfu genpkg --dev-type 0x0052 --sd-req {build.sd_fwid} --application "{build.path}/{build.project_name}.hex" "{build.path}/{build.project_name}.zip"
 
 ## Create uf2 file
-recipe.objcopy.uf2.pattern="{tools.uf2conv.cmd}" -f 0xADA52840 -c -o "{build.path}/{build.project_name}.uf2" "{build.path}/{build.project_name}.hex"
+recipe.objcopy.uf2.pattern={tools.uf2conv.cmd} -f 0xADA52840 -c -o "{build.path}/{build.project_name}.uf2" "{build.path}/{build.project_name}.hex"
 
 ## Save bin
 recipe.output.tmp_file_bin={build.project_name}.bin


### PR DESCRIPTION
Quoting the uf2conv command in the recipe target on Linux causes a failed build every time. This PR provides a fix.
