### PR TITLE
Fixed uf2conv.py

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -134,7 +134,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.hex
 # https://github.com/adafruit/Adafruit_nRF52_nrfutil
 # pre-built binaries are provided for macos and windows
 # ------------------------------------------------
-tools.uf2conv.cmd=python {runtime.platform.path}/tools/uf2conv/uf2conv.py
+tools.uf2conv.cmd={runtime.platform.path}/tools/uf2conv/uf2conv.py
 tools.uf2conv.cmd.windows={runtime.platform.path}/tools/uf2conv/uf2conv.exe
 tools.uf2conv.cmd.macosx=python {runtime.platform.path}/tools/uf2conv/uf2conv.py
 

--- a/platform_board_manager.txt
+++ b/platform_board_manager.txt
@@ -110,7 +110,7 @@ recipe.objcopy.hex.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf
 recipe.objcopy.zip.pattern="{tools.nrfutil.cmd}" dfu genpkg --dev-type 0x0052 --sd-req {build.sd_fwid} --application "{build.path}/{build.project_name}.hex" "{build.path}/{build.project_name}.zip"
 
 ## Create uf2 file
-#recipe.objcopy.uf2.pattern=python "{runtime.platform.path}/tools/uf2conv/uf2conv.py" -f 0xADA52840 -c -o "{build.path}/{build.project_name}.uf2" "{build.path}/{build.project_name}.hex"
+#recipe.objcopy.uf2.pattern="{runtime.platform.path}/tools/uf2conv/uf2conv.py" -f 0xADA52840 -c -o "{build.path}/{build.project_name}.uf2" "{build.path}/{build.project_name}.hex"
 
 ## Save bin
 recipe.output.tmp_file_bin={build.project_name}.bin

--- a/tools/platform.txt
+++ b/tools/platform.txt
@@ -134,7 +134,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.hex
 # https://github.com/adafruit/Adafruit_nRF52_nrfutil
 # pre-built binaries are provided for macos and windows
 # ------------------------------------------------
-tools.uf2conv.cmd=python {runtime.platform.path}/tools/uf2conv/uf2conv.py
+tools.uf2conv.cmd={runtime.platform.path}/tools/uf2conv/uf2conv.py
 tools.uf2conv.cmd.windows={runtime.platform.path}/tools/uf2conv/uf2conv.exe
 tools.uf2conv.cmd.macosx=python {runtime.platform.path}/tools/uf2conv/uf2conv.py
 

--- a/tools/platform_git.txt
+++ b/tools/platform_git.txt
@@ -134,7 +134,7 @@ recipe.output.save_file={build.project_name}.{build.variant}.hex
 # https://github.com/adafruit/Adafruit_nRF52_nrfutil
 # pre-built binaries are provided for macos and windows
 # ------------------------------------------------
-tools.uf2conv.cmd=python {runtime.platform.path}/tools/uf2conv/uf2conv.py
+tools.uf2conv.cmd={runtime.platform.path}/tools/uf2conv/uf2conv.py
 tools.uf2conv.cmd.windows={runtime.platform.path}/tools/uf2conv/uf2conv.exe
 tools.uf2conv.cmd.macosx=python {runtime.platform.path}/tools/uf2conv/uf2conv.py
 

--- a/tools/uf2conv/uf2conv.py
+++ b/tools/uf2conv/uf2conv.py
@@ -174,7 +174,7 @@ def get_drives():
                                      "get", "DeviceID,", "VolumeName,",
                                      "FileSystem,", "DriveType"])
         for line in r.split('\n'):
-            words = re.split('\s+', line)
+            words = re.split(r'\s+', line)
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:


### PR DESCRIPTION
On Linux (Fedora 41 tested) Arduino IDE fails to run uf2conv.py (maybe because the python path isn't set by Arduino IDE?). Starting the script directly works OK, but it requires executable mode.

Also fixed warning that shows in the Arduino IDE output console every time the uf2conv.py script is run:
  SyntaxWarning: invalid escape sequence '\s'